### PR TITLE
fix tmp/breadcrumbs

### DIFF
--- a/tmp/breadcrumbs.php
+++ b/tmp/breadcrumbs.php
@@ -7,14 +7,14 @@
  */
 
 if (is_single_breadcrumbs_visible() && (is_single() || is_category())):
-$cat = get_the_category();
+  $cat = get_category($cat);
 if($cat && !is_wp_error($cat)){
   $echo = null;
   //var_dump($par);
   echo '<div id="breadcrumb" class="breadcrumb breadcrumb-category'.get_additional_single_breadcrumbs_classes().'" itemscope itemtype="https://schema.org/BreadcrumbList">';
   echo '<div class="breadcrumb-home" itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement"><span class="fa fa-home fa-fw"></span><a href="'.home_url().'" itemprop="item"><span itemprop="name">'.__( 'ホーム', THEME_NAME ).'</span></a><meta itemprop="position" content="1" /><span class="sp"><span class="fa fa-angle-right"></span></span></div>';
   $count = 1;
-  $par = get_category($cat[0]->parent);
+  $par = get_category($cat->parent);
   //カテゴリ情報の取得
   $cats = array();
   while($par && !is_wp_error($par) && $par->term_id != 0){
@@ -32,11 +32,11 @@ if($cat && !is_wp_error($cat)){
   //var_dump($cats);
   // // 親カテゴリまで表示する場合
   // ++$count;
-  // echo $echo.'<div class="breadcrumb-item" itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement"><span class="fa fa-folder fa-fw"></span><a href="'.get_category_link($cat[0]->term_id).'" itemprop="item"><span itemprop="name">'.$cat[0]->name.'</span></a><meta itemprop="position" content="'.$count.'" /></div>';
+  // echo $echo.'<div class="breadcrumb-item" itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement"><span class="fa fa-folder fa-fw"></span><a href="'.get_category_link($cat->term_id).'" itemprop="item"><span itemprop="name">'.$cat->name.'</span></a><meta itemprop="position" content="'.$count.'" /></div>';
 
   // 現カテゴリの出力
   ++$count;
-  echo $echo.'<div class="breadcrumb-item" itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement"><span class="fa fa-folder fa-fw"></span><a href="'.get_category_link($cat[0]->term_id).'" itemprop="item"><span itemprop="name">'.$cat[0]->name.'</span></a><meta itemprop="position" content="'.$count.'" />';
+  echo $echo.'<div class="breadcrumb-item" itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement"><span class="fa fa-folder fa-fw"></span><a href="'.get_category_link($cat->term_id).'" itemprop="item"><span itemprop="name">'.$cat->name.'</span></a><meta itemprop="position" content="'.$count.'" />';
   //ページタイトルを含める場合はセパレーターを表示
   if (is_single_breadcrumbs_include_post() && is_singular()) {
     echo '<span class="sp"><span class="fa fa-angle-right"></span></span>';

--- a/tmp/breadcrumbs.php
+++ b/tmp/breadcrumbs.php
@@ -7,7 +7,7 @@
  */
 
 if (is_single_breadcrumbs_visible() && (is_single() || is_category())):
-  $cat = get_category($cat);
+  $cat = is_single() ? get_the_category()[0] : get_category(get_query_var("cat"));
 if($cat && !is_wp_error($cat)){
   $echo = null;
   //var_dump($par);


### PR DESCRIPTION
カテゴリ用のパンくずリストで、選択中のカテゴリではなく
カテゴリページに表示される記事一覧の１つ目の記事のカテゴリ（複数ある場合は、その１つ目）が
表示されていたのを修正