### PR TITLE
Bug fix onTouchStart is not defined

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -87,5 +87,5 @@
 
 //Passive Event Listener を使用してサイトでのスクロール パフォーマンスを向上させる
 if ('ontouchstart' in document.documentElement) {
-    document.addEventListener('touchstart', onTouchStart, {passive: true});
+    document.addEventListener('touchstart', function(){}, {passive: true});
 }


### PR DESCRIPTION
【概要】
onTouchStart is not definedが発生しておりスクロールイベントが実行されない
【対応】
onTouchStartを空functionに修正

https://blog.webico.work/passive-event-listeber01