### PR TITLE
#18 date_default_timezone_set を削除し date_i18n を使用するように修正

### DIFF
--- a/lib/shortcodes-amazon.php
+++ b/lib/shortcodes-amazon.php
@@ -396,8 +396,7 @@ function amazon_product_link_shortcode($atts){
       $unix_date = (string)$xml->OperationRequest->Arguments->Argument[6]->attributes()->Value;
       if ($unix_date) {
         $timestamp = strtotime($unix_date);//UNIX形式の日付文字列をタイムスタンプに変換
-        date_default_timezone_set(__( 'Asia/Tokyo', THEME_NAME ));
-        $acquired_date = date(__( 'Y/m/d H:i', THEME_NAME ), $timestamp);//フォーマット変更
+        $acquired_date = date_i18n(__( 'Y/m/d H:i', THEME_NAME ), $timestamp);//フォーマット変更
         //_v($acquired_date);
         //_v($FormattedPrice);
         if ((is_amazon_item_price_visible() || $price === '1')

--- a/lib/shortcodes-rakuten.php
+++ b/lib/shortcodes-rakuten.php
@@ -148,8 +148,7 @@ function rakuten_product_link_shortcode($atts){
     $is_request_success = !is_wp_error( $json ) && $json['response']['code'] === 200;
     //リクエストが成功した時タグを作成する
     if ($is_request_success) {
-      date_default_timezone_set(__( 'Asia/Tokyo', THEME_NAME ));
-      $acquired_date = date(__( 'Y/m/d H:i', THEME_NAME ));
+      $acquired_date = date_i18n(__( 'Y/m/d H:i', THEME_NAME ));
 
       //キャッシュの保存
       if (!$json_cache) {


### PR DESCRIPTION
# 概要
#18 

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
date_default_timezone_set を削除し date_i18n を使用するように修正 

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
do_shortcodeでamazonと楽天のショートコードが使用されていた場合に、それ以降でdateに関する関数が使用されていた場合

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->