### PR TITLE
Fix Twitter account of OGP tag

### DIFF
--- a/tmp/header-twitter-card.php
+++ b/tmp/header-twitter-card.php
@@ -63,7 +63,7 @@ if (is_singular()){//単一記事ページの場合
 ?>
 <meta name="twitter:domain" content="<?php echo get_the_site_domain() ?>">
 <?php if ( get_the_author_twitter_url() )://TwitterIDが設定されている場合 ?>
-<meta name="twitter:creator" content="@<?php echo esc_html( get_the_author_twitter_url() ) ?>">
-<meta name="twitter:site" content="@<?php echo esc_html( get_the_author_twitter_url() ) ?>">
+<meta name="twitter:creator" content="@<?php echo esc_html( get_the_author_twitter_id() ) ?>">
+<meta name="twitter:site" content="@<?php echo esc_html( get_the_author_twitter_id() ) ?>">
 <?php endif; ?>
 <!-- /Twitter Card -->


### PR DESCRIPTION
OGPタグの`twitter:creator`と`twitter:site`は`@username`で指定するようなのですが、TwitterアカウントのURLがそのまま指定されていたので修正しました。

下記URLの`Card and Content Attribution`のセクションに`twitter:creator`と`twitter:site`についての記述があります。
https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started