### PR TITLE
fix "PHP Warning"

### DIFF
--- a/lib/theme-update-checker.php
+++ b/lib/theme-update-checker.php
@@ -179,6 +179,7 @@ class ThemeUpdateChecker {
 
 		//Is there an update to insert?
 		if ( !empty($state) && isset($state->update) && !empty($state->update) ){
+			$updates = new StdClass;
 			$updates->response[$this->theme] = $state->update->toWpFormat();
 		}
 


### PR DESCRIPTION
# PHP7.4 の環境でWarningが出てしまいました

以下

## 環境

* Ubuntu 18.04
* WP-CLI 2.4.0
* PHP 7.4.1
* WordPress 5.3.2
* cocoon-master 2.0.5


### Warning 

wpコマンド使って確認できました

```sh
(master *) $ sudo -uwww-data /usr/local/bin/wp theme update --all --path=/home/username/sites/XXXXXX.com/wordpress
メンテナンスモードを有効にします…
https://wp-cocoon.com/download/791/ から更新をダウンロード中...
更新を展開しています…
最新のバージョンをインストールしています…
旧バージョンのテーマを削除しています…
テーマの更新に成功しました。
メンテナンスモードを無効にします…
PHP Warning:  Creating default object from empty value in /home/username/sites/XXXXXX.com/wordpress/wp-content/themes/cocoon-master/lib/theme-update-checker.php on line 183
Success: Updated 1 of 1 themes.
```

### 修正を追加

```diff
diff --git a/lib/theme-update-checker.php b/lib/theme-update-checker.php
index aca98a2..042f54e 100644
--- a/lib/theme-update-checker.php
+++ b/lib/theme-update-checker.php
@@ -179,6 +179,7 @@ class ThemeUpdateChecker {

                //Is there an update to insert?
                if ( !empty($state) && isset($state->update) && !empty($state->update) ){
+                       $updates = new StdClass;
                        $updates->response[$this->theme] = $state->update->toWpFormat();
                }
```

### Warningが出なくなりました


```sh
(master *) $ sudo -uwww-data /usr/local/bin/wp theme update --all --path=/home/username/sites/XXXXXX.com/wordpress
メンテナンスモードを有効にします…
https://wp-cocoon.com/download/791/ から更新をダウンロード中...
更新を展開しています…
最新のバージョンをインストールしています…
旧バージョンのテーマを削除しています…
テーマの更新に成功しました。
メンテナンスモードを無効にします…
Success: Updated 1 of 1 themes.
```