### PR TITLE
本文の投稿者名の表示を無効にした際にauthorのURLの出力を抑制

### DIFF
--- a/tmp/footer-meta.php
+++ b/tmp/footer-meta.php
@@ -7,7 +7,7 @@
  */
 if ( !defined( 'ABSPATH' ) ) exit;
 
-if (get_the_author()) {
+if (is_post_author_visible() && get_the_author()) {
   $author_id = get_the_author_meta( 'ID' );
   $profile_page_url = get_the_author_profile_page_url($author_id);
   if ($profile_page_url) {


### PR DESCRIPTION
投稿者名を非表示にする場合、セキュリティ上の理由でアカウント名が入ってしまうauthorのURLの出力止めたい場合があるかと思いますので、ご検討ください。