### PR TITLE
メインカテゴリがない場合 Undefined variable が発生するバグの修正

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -79,7 +79,7 @@ function get_the_nolink_category($id = null, $is_visible = true){
   }
 
   //メインカテゴリがない場合は先頭のカテゴリを適用
-  if (!$category) {
+  if ( ! isset( $category ) ) {
     $category = $categories[0];
   }
 


### PR DESCRIPTION
こんにちは、ありがたく使わせていただいています。

メインカテゴリがない場合、次の Notice が発生します:

```console
[21-Jun-2020 14:09:50 UTC] PHP Notice:  Undefined variable: category in /app/web/app/themes/cocoon/lib/utils.php on line 82
[21-Jun-2020 14:09:50 UTC] PHP Stack trace:
[21-Jun-2020 14:09:50 UTC] PHP   1. {main}() /app/web/index.php:0
[21-Jun-2020 14:09:51 UTC] PHP   2. require() /app/web/index.php:5
[21-Jun-2020 14:09:51 UTC] PHP   3. require_once() /app/web/wp/wp-blog-header.php:19
[21-Jun-2020 14:09:51 UTC] PHP   4. include() /app/web/wp/wp-includes/template-loader.php:106
[21-Jun-2020 14:09:51 UTC] PHP   5. get_template_part() /app/web/app/themes/cocoon/single.php:18
[21-Jun-2020 14:09:51 UTC] PHP   6. locate_template() /app/web/wp/wp-includes/general-template.php:168
[21-Jun-2020 14:09:51 UTC] PHP   7. load_template() /app/web/wp/wp-includes/template.php:672
[21-Jun-2020 14:09:51 UTC] PHP   8. require() /app/web/wp/wp-includes/template.php:725
[21-Jun-2020 14:09:51 UTC] PHP   9. get_template_part() /app/web/app/themes/cocoon/tmp/single-contents.php:29
[21-Jun-2020 14:09:51 UTC] PHP  10. locate_template() /app/web/wp/wp-includes/general-template.php:168
[21-Jun-2020 14:09:51 UTC] PHP  11. load_template() /app/web/wp/wp-includes/template.php:672
[21-Jun-2020 14:09:51 UTC] PHP  12. require() /app/web/wp/wp-includes/template.php:725
[21-Jun-2020 14:09:51 UTC] PHP  13. get_template_part() /app/web/app/themes/cocoon/tmp/related-entries.php:23
[21-Jun-2020 14:09:51 UTC] PHP  14. locate_template() /app/web/wp/wp-includes/general-template.php:168
[21-Jun-2020 14:09:51 UTC] PHP  15. load_template() /app/web/wp/wp-includes/template.php:672
[21-Jun-2020 14:09:51 UTC] PHP  16. require() /app/web/wp/wp-includes/template.php:725
[21-Jun-2020 14:09:51 UTC] PHP  17. get_template_part() /app/web/app/themes/cocoon/tmp/related-list.php:17
[21-Jun-2020 14:09:51 UTC] PHP  18. locate_template() /app/web/wp/wp-includes/general-template.php:168
[21-Jun-2020 14:09:51 UTC] PHP  19. load_template() /app/web/wp/wp-includes/template.php:672
[21-Jun-2020 14:09:51 UTC] PHP  20. require() /app/web/wp/wp-includes/template.php:725
[21-Jun-2020 14:09:51 UTC] PHP  21. the_nolink_category() /app/web/app/themes/cocoon/tmp/related-entry-card.php:19
[21-Jun-2020 14:09:51 UTC] PHP  22. get_the_nolink_category() /app/web/app/themes/cocoon/lib/utils.php:97
```