### PR TITLE
ヘッダータグの階層が飛んでいる場合の目次表示の対応

### DIFF
--- a/lib/toc.php
+++ b/lib/toc.php
@@ -131,7 +131,7 @@ function get_toc_tag($expanded_content, &$harray, $is_widget = false, $depth_opt
       }
       //$counters[$current_depth - 1] ++;
       $hide_class = null;
-      if ($depth == $depth_option) {
+      if ( $depth_option != 0 && $depth >= $depth_option ) {
         $hide_class = ' class="display-none"';
       }
       $counter++;


### PR DESCRIPTION
例:

```html
<h2>Header level 2</h2>
<h3>Header level 3</h3>
<h2>Header level 2</h2>
<h4>Header level 4</h4>
<h5>Header level 5</h5>
```

上記の場合にも、`[toc depth=3]` で次の表示をサポートします。

- Header level 2
  - Header level 3
- Header level 2

この記法は SEO 的には諸説ありますが、
W3C Markup Validation Service のチェックでは問題ないようです。

https://validator.w3.org/