### PR TITLE
Amazon のリンクを外部ブログカードに表示する際、商品画像が表示されなくなっていた問題を修正

### DIFF
--- a/lib/open-graph.php
+++ b/lib/open-graph.php
@@ -223,12 +223,18 @@ class OpenGraphGetter implements Iterator
               //_v($m[0]);
               $image_url = $m[1];
             }
+          //https://m.media-amazon.com/images/I/51QZhiaZqRL._AC_.jpg
+          //https://m.media-amazon.com/images/I/61Hs3z66UFL._AC_SY450_.jpg
+          } else if (preg_match('/id="landingImage" data-a-dynamic-image="\{&quot;(https:\/\/m\.media-amazon\.com\/images\/I\/.+?\.jpg)&quot;:/i', $HTML, $m)) {
+            if (isset($m[1])) {
+              $image_url = $m[1];
+            }
           }
         }
       } else if (includes_string($HTML, 'id="imgBlkFront"')) {
         //書籍ページ用
         //https://images-fe.ssl-images-amazon.com/images/I/51aV7NaxG4L.jpg
-        $res = preg_match('/id="imgBlkFront" data-a-dynamic-image="\{&quot;(https:\/\/images-(fe|na).ssl-images-amazon.com\/images\/I\/.+?\.jpg)&quot;:/i', $HTML, $m);
+        $res = preg_match('/id="imgBlkFront" data-a-dynamic-image="\{&quot;(https:\/\/images-(fe|na)\.ssl-images-amazon\.com\/images\/I\/.+?\.jpg)&quot;:/i', $HTML, $m);
         if ($res && isset($m[1])) {
           $image_url = $m[1];
         }
@@ -236,14 +242,14 @@ class OpenGraphGetter implements Iterator
         //Amazon Music
         //https://m.media-amazon.com/images/I/61+mhXhVhfL._SS500_.jpg
         //https://images-na.ssl-images-amazon.com/images/I/41AFHM036KL._AC_.jpg
-        $res = preg_match('/<img.+?src="(https:\/\/m.media-amazon.com\/images\/I\/.+?)">/i', $HTML, $m);
+        $res = preg_match('/<img.+?src="(https:\/\/m\.media-amazon\.com\/images\/I\/.+?)">/i', $HTML, $m);
         if ($res && isset($m[1])) {
           $image_url = $m[1];
         }
       } else if (includes_string($HTML, 'id="ebooksImgBlkFront"')) {
         //Amazon Kindle
         //https://m.media-amazon.com/images/I/51tY7U5mUHL.jpg
-        $res = preg_match('/"(https:\/\/m.media-amazon\.com\/images\/I\/[^&"]+?\.jpg)"/i', $HTML, $m);
+        $res = preg_match('/"(https:\/\/m\.media-amazon\.com\/images\/I\/[^&"]+?\.jpg)"/i', $HTML, $m);
         if ($res && isset($m[1])) {
           $image_url = $m[1];
         }


### PR DESCRIPTION
いつも Cocoon テーマを使わせて頂いています。

さて、以前は Amazon のリンクを外部ブログカードに表示する際、ちゃんと商品画像が表示されていたかと思うのですが、いつ頃からか商品画像ではなくサイト全体のスクリーンショットが表示されるようになっていました。
[こちら](https://wp-cocoon.com/community/cocoon-theme/%E5%A4%96%E9%83%A8%E3%83%96%E3%83%AD%E3%82%B0%E3%82%AB%E3%83%BC%E3%83%89%E3%81%AE%E7%94%BB%E5%83%8F%E3%83%87%E3%83%BC%E3%82%BF%E5%8F%96%E5%BE%97%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6/) のフォーラムの回答を読む限り、OGP が設定されておらず画像が取得できないときは、代わりにサイト全体のスクリーンショットを取得するような仕様になっているようです。

そのあたりの仕様を考慮して原因を調査したところ、Amazon 側の商品画像の URL 構造が変更になった影響で、Amazon の HTML から商品画像の URL をスクレイピングで取得するコードが正しく動作していない事が分かりました。  
書籍ページまでは検証できていませんが、少なくとも一般的な商品ページでは商品画像が取得できなくなっているようです。

そこで、既存の正規表現パターンで商品画像を取得できなかった場合に、現在の Amazon の仕様に合わせた別の正規表現パターンで商品画像の取得を試みるように変更しました。
実際、このコードで再び商品画像が表示されるようになった事を確認できています。なぜか他の外部ブログカードのサムネイルとは異なり正方形でトリミングされていますが、これは Cocoon 側の仕様なのでしょうか。
また、他の正規表現コードには . (ドット) のエスケープを忘れていると思われる部分があったので、エスケープを追加しています（正規表現において . は改行を除く全ての文字を意味するので、結果的にエスケープしなくても動作していたのだと思います）。

そもそも Amazon だけこのようにスクレイピングするコードになっている理由は Amazon の HTML に OGP タグが見当たらないからだと思うのですが、実は User-Agent を Twitterbot/1.0 に偽装した状態で Amazon の HTML を取得すると、HTML 中に OGP タグが含まれる事を確認しています（なぜそういう仕様になっているのかは謎です）。
Amazon 側の仕様変更に左右されずに安定して商品画像を取得したいのであれば、（少なくとも、フォールバックとして）User-Agent を偽装して Amazon の HTML を取得し、OGP タグから商品画像を取得することをおすすめします。