### PR TITLE
[fix] カスタムタクソノミーのタームのタグタイトル・タグ本文などが更新できない不具合修正

### DIFF
--- a/lib/content-tag.php
+++ b/lib/content-tag.php
@@ -253,7 +253,7 @@ endif;
 add_action ( 'edited_term', 'save_extra_tag_fileds');
 if ( !function_exists( 'save_extra_tag_fileds' ) ):
 function save_extra_tag_fileds( $term_id ) {
-  if (isset($_POST['taxonomy']) && ($_POST['taxonomy'] === 'post_tag')) {
+  if (isset($_POST['taxonomy'])) {
     $tag_id = $term_id;
 
     if ( isset( $_POST['the_tag_title'] ) ) {


### PR DESCRIPTION
![ScreenShot 2022-01-18 15 25 05](https://user-images.githubusercontent.com/15831991/149882319-a39d13f2-9dea-4ee8-8ecf-e6f98bed8706.jpg)

カスタムタクソノミーのターム編集画面で、`タグタイトル`・`タグ本文`・`アイキャッチ`・`メタディスクリプション`・`メタキーワード`・`noindex `を編集しても更新されない不具合がありましたので、更新できるように修正致しました。

原因としましては、
`lib/category-tag.php`に`post_tag`限定で更新処理をするように書かれておりましたので、
カスタムタクソノミーのタームでも変更できるように、その条件を削除致しました。

修正前：
```php
if (isset($_POST['taxonomy']) && ($_POST['taxonomy'] === 'post_tag')) {
```

修正後：
```php
if (isset($_POST['taxonomy'])) {
```

ご確認いただければ幸いです。