### PR TITLE
Deprecated:  uasort() の修正

### DIFF
--- a/lib/page-settings/skin-funcs.php
+++ b/lib/page-settings/skin-funcs.php
@@ -81,7 +81,7 @@ function skin_files_comp($a, $b) {
   if ($f1 == $f2) {
       $n1 = (float)isset($a['skin_name']) ? $a['skin_name'] : 99999999999;
       $n2 = (float)isset($b['skin_name']) ? $b['skin_name'] : 99999999999;
-      return $n1 > $n2;
+      return $n1 <=> $n2;
   }
   return ($f1 < $f2) ? -1 : 1;
 }


### PR DESCRIPTION
PHP 8.0.0 にて以下の Deprecated が出ていましたので、修正してみました。

`
PHP Deprecated:  uasort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero in \code\app\public\wp-content\themes\cocoon-master\lib\page-settings\skin-funcs.php on line 221`

--- 環境情報 ---

[Local](https://localwp.com/) で作ったローカル環境です。

- WordPressバージョン：6.0.1
- PHPバージョン：8.0.0
- サーバーソフト：Apache/2.4.43

--- Deprecated が出るタイミング ---

Cocoon 設定 > スキンタブを開いた時です。