### PR TITLE
FAQの構造化データの重複除去

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -392,6 +392,12 @@ function cocoon_add_faq($content, $block, $faq, $question) {
   }
   $text = strip_tags(str_replace(["\n", "\r"], '', $answer), '<h1><h2><h3><h4><h5><h6><br><ol><ul><li><a><p><div><b><strong><i><em>');
 
+  foreach ($faq as $key => $value) {
+    if ( $value["name"] === $name) {
+      return $faq;
+    }
+  }
+
   $faq[count($faq)] = [
     '@type'          => 'Question',
     'name'           => $name,


### PR DESCRIPTION
https://wp-cocoon.com/community/bugs/faq%e3%83%96%e3%83%ad%e3%83%83%e3%82%af%e3%81%a7%e4%bd%9c%e6%88%90%e3%81%95%e3%82%8c%e3%81%9f%e6%a7%8b%e9%80%a0%e5%8c%96%e3%83%87%e3%83%bc%e3%82%bf%ef%bc%88json-ld%ef%bc%89%e3%81%ae%e5%86%85%e5%ae%b9/#post-63888

この件の対応